### PR TITLE
Fix: slight X-axis adjustment to StatCodeLineNumbers

### DIFF
--- a/R/StatCode.R
+++ b/R/StatCode.R
@@ -6,31 +6,31 @@
 #' @importFrom tidyr unnest
 
 compute_panel_code <- function(data, scales){
-  
+
  data |>
-    mutate(row = row_number()) |> 
-    mutate(is_highlighted = str_detect(.data$code, "#<<")) |> 
+    mutate(row = row_number()) |>
+    mutate(is_highlighted = str_detect(.data$code, "#<<")) |>
     mutate(code = str_remove(.data$code, "#<<")) |>
     mutate(code = str_remove(.data$code, "^#$")) |>
     mutate(code = str_split(.data$code, "")) |>
     unnest(code) |>
-    group_by(row) |> 
+    group_by(row) |>
     mutate(x = row_number()) |>
     mutate(is_character = .data$code != " ") |>
     mutate(is_code = cumsum(.data$is_character) |> as.logical()) |>
     filter(.data$is_code) |>
     mutate(label = .data$code)
-  
+
 }
 
 
 
 
 compute_panel_code_line_numbers <- function(data, scales){
-  
+
  data |>
-    mutate(row = row_number()) 
-  
+    mutate(row = row_number())
+
 }
 
 #' @importFrom ggplot2 ggproto aes after_stat Stat
@@ -44,7 +44,7 @@ StatCode <- ggproto("StatCode", Stat,
 StatCodeLineNumbers <- ggproto("StatCodeLineNumbers", Stat,
                     compute_panel = compute_panel_code_line_numbers,
                     default_aes = aes(y = after_stat(row),
-                                      x = after_stat(-0.5),
+                                      x = after_stat(-2.3),
                                       hjust = after_stat(1),
                                       label = after_stat(row))
                     )

--- a/README.Rmd
+++ b/README.Rmd
@@ -137,7 +137,7 @@ StatCode <- ggproto("StatCode", Stat,
 StatCodeLineNumbers <- ggproto("StatCodeLineNumbers", Stat,
                     compute_panel = compute_panel_code_line_numbers,
                     default_aes = aes(y = after_stat(row),
-                                      x = after_stat(-0.5),
+                                      x = after_stat(-2.3),
                                       hjust = after_stat(1),
                                       label = after_stat(row))
                     )
@@ -336,10 +336,10 @@ stamp_graph_paper <- function(){
   
 }
 
-ggplot(cars) + 
-  stamp_graph_paper() + 
-  aes(speed,dist) + 
-  geom_point()
+# ggplot(cars) + 
+#   stamp_graph_paper() + 
+#   aes(speed,dist) + 
+#   geom_point()
 ```
 
 


### PR DESCRIPTION
These two commits bundle the same change to the X-axis of line numbers so the punched holes dont hide them

- One commit changed the actual StatCode.R
- The other changed the README.Rmd




(which kinda defeats the purpose, i need to get used to rdme first approach)